### PR TITLE
issue4 ファットフラグメントの回避

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchListAdapter.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchListAdapter.kt
@@ -1,0 +1,49 @@
+package jp.co.yumemi.android.code_check
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import jp.co.yumemi.android.code_check.databinding.LayoutItemBinding
+
+class SearchListAdapter(
+    private val itemClickListener: OnItemClickListener,
+) : ListAdapter<item, SearchListAdapter.ViewHolder>(diffUtil) {
+
+    class ViewHolder(
+        private val binding: LayoutItemBinding,
+        private val itemClickListener: OnItemClickListener,
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: item) {
+            binding.repositoryNameView.text = item.name
+            binding.root.setOnClickListener {
+                itemClickListener.itemClick(item)
+            }
+        }
+    }
+
+    interface OnItemClickListener {
+        fun itemClick(item: item)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = LayoutItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding, itemClickListener)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+private val diffUtil = object : DiffUtil.ItemCallback<item>() {
+    override fun areItemsTheSame(oldItem: item, newItem: item): Boolean {
+        return oldItem.name == newItem.name
+    }
+
+    override fun areContentsTheSame(oldItem: item, newItem: item): Boolean {
+        return oldItem == newItem
+    }
+
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchRepositoryFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchRepositoryFragment.kt
@@ -9,7 +9,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -45,8 +44,8 @@ class SearchRepositoryFragment : Fragment() {
         }
     }
 
-    private fun setupAdapter(): CustomAdapter {
-        return CustomAdapter(object : CustomAdapter.OnItemClickListener {
+    private fun setupAdapter(): SearchListAdapter {
+        return SearchListAdapter(object : SearchListAdapter.OnItemClickListener {
             override fun itemClick(item: item) {
                 gotoRepositoryFragment(item)
             }
@@ -92,40 +91,3 @@ class SearchRepositoryFragment : Fragment() {
     }
 }
 
-private val diffUtil = object : DiffUtil.ItemCallback<item>() {
-    override fun areItemsTheSame(oldItem: item, newItem: item): Boolean {
-        return oldItem.name == newItem.name
-    }
-
-    override fun areContentsTheSame(oldItem: item, newItem: item): Boolean {
-        return oldItem == newItem
-    }
-
-}
-
-private class CustomAdapter(
-    private val itemClickListener: OnItemClickListener,
-) : ListAdapter<item, CustomAdapter.ViewHolder>(diffUtil) {
-
-    class ViewHolder(view: View) : RecyclerView.ViewHolder(view)
-
-    interface OnItemClickListener {
-        fun itemClick(item: item)
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.layout_item, parent, false)
-        return ViewHolder(view)
-    }
-
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val item = getItem(position)
-        (holder.itemView.findViewById<View>(R.id.repositoryNameView) as TextView).text =
-            item.name
-
-        holder.itemView.setOnClickListener {
-            itemClickListener.itemClick(item)
-        }
-    }
-}


### PR DESCRIPTION
## 概要
- `CustomAdapter`の削除し新たに`SearchListAdapter`として切り出した。
- `ViewBinding`を使用しモダンな実装にした。
これにより、ファットフラグメントの回避となる。

## 変更点
- `CustomAdapter.kt`を削除した。
- アダプタークラスを`CustomAdapter`から`SearchListAdapter`にリネームした。
- `SearchListAdapter`が`ViewBinding`を使用していなかったため変更した。
- `DiffUtil.ItemCallback`の実装を`SearchListAdapter`に移動した。

## 動作環境
- Android Studio Flamingo | 2022.2.1 Patch 1
- Build #AI-222.4459.24.2221.9971841, built on April 20, 2023
- Runtime version: 17.0.6+0-17.0.6b802.4-9586694 aarch64VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
- macOS 14.1.1
- GC: G1 Young Generation, G1 Old Generation
- Memory: 2048M
- Cores: 8
- Metal Rendering is ON

- Pixel 7a (Android 13) 実機