### PR TITLE
feat: ProgressBarを追加した.

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragment/SearchRepositoryFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/fragment/SearchRepositoryFragment.kt
@@ -46,6 +46,9 @@ class SearchRepositoryFragment : Fragment() {
         viewModel.gitHubRepositoryItems.observe(viewLifecycleOwner) {
             adapter.submitList(it)
         }
+        viewModel.isLoading.observe(viewLifecycleOwner) {
+            binding.progressBar.visibility = if (it) View.VISIBLE else View.GONE
+        }
     }
 
     private fun setupAdapter(): SearchListAdapter {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/viewModel/SearchRepositoryViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/viewModel/SearchRepositoryViewModel.kt
@@ -22,17 +22,23 @@ class SearchRepositoryViewModel @Inject constructor(
     private val _gitHubRepositoryItems = MutableLiveData<List<GitHubRepositoryItem>>()
     val gitHubRepositoryItems: LiveData<List<GitHubRepositoryItem>> = _gitHubRepositoryItems
 
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
+
     private val _error = MutableLiveData<String>()
 
     fun searchRepository(query: String) {
+        _isLoading.value = true
         viewModelScope.launch {
             repository.searchRepository(query).fold(
                 onSuccess = {
                     _gitHubRepositoryItems.postValue(it)
+                    _isLoading.postValue(false)
                     lastSearchDate = Date()
                 },
                 onFailure = {
                     _error.postValue(it.message)
+                    _isLoading.postValue(false)
                 }
             )
         }

--- a/app/src/main/res/layout/fragment_search_repository.xml
+++ b/app/src/main/res/layout/fragment_search_repository.xml
@@ -49,6 +49,18 @@
 
     </com.google.android.material.card.MaterialCardView>
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:progressTint="@color/teal_200"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="0dp"


### PR DESCRIPTION
## 機能: プログレスバーの追加

- 検索クエリが処理中の間に表示されるプログレスバーを追加しました。
- プログレスバーは、ユーザーが検索クエリを送信した後に表示され、検索結果がロードされると消えます。
- 初期読み込み時にはプログレスバーが隠され、ユーザーの操作によってのみアクティブになるようにしました。


## スクリーンショット

https://github.com/Mgtantheta/android-engineer-codecheck/assets/114408959/6ed3a767-fe98-4fa9-973e-4ca9b88a58fb


## 追加ノート
- プログレスバーのロジックを収容するために、検索機能をリファクタリングしました。
- 必要なIDと文字列を`res/values/ids.xml`と`res/values/strings.xml`に追加しました。

## 関連する問題
- このPRが既存の問題を解決する場合は、#123のように記載します。

## 動作環境
- Android Studio Flamingo | 2022.2.1 Patch 1
- Build #AI-222.4459.24.2221.9971841, built on April 20, 2023
- Runtime version: 17.0.6+0-17.0.6b802.4-9586694 aarch64VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
- macOS 14.1.1
- GC: G1 Young Generation, G1 Old Generation
- Memory: 2048M
- Cores: 8
- Metal Rendering is ON
- Pixel 7a (Android 13) 実機